### PR TITLE
修复 form-item label 超过2个字时换行的问题

### DIFF
--- a/uview-ui/components/u-form-item/u-form-item.vue
+++ b/uview-ui/components/u-form-item/u-form-item.vue
@@ -183,7 +183,7 @@ export default {
 		// label的宽度
 		elLabelWidth() {
 			// label默认宽度为90，优先使用本组件的值，如果没有(如果设置为0，也算是配置了值，依然起效)，则用u-form的值
-			return (this.labelWidth != 0 || this.labelWidth != '') ? this.labelWidth : (this.parent ? this.parent.labelWidth : 90);
+			return (this.labelWidth != 0 || this.labelWidth != '') ? this.labelWidth : (this.parent ? this.parent.labelWidth : 90) + 10;
 		},
 		// label的样式
 		elLabelStyle() {


### PR DESCRIPTION
因为下面样式里有个 padding-right: 10rpx; 当label字数超过2个的时候，小程序端label就会因为内容宽度不够而换行。需要加上10来调整