### PR TITLE
一脸懵逼！你不让处理，上面逻辑为什么 reject ？？

### DIFF
--- a/uview-ui/libs/request/index.js
+++ b/uview-ui/libs/request/index.js
@@ -91,11 +91,7 @@ class Request {
 				}, this.config.loadingTime);
 			}
 			uni.request(options);
-		}).catch(res => {
-			// 如果返回reject()，不让其进入this.$u.post().then().catch()后面的catct()
-			// 因为很多人都会忘了写后面的catch()，导致报错捕获不到catch
-			return new Promise(()=>{});
-		})
+		});
 	}
 
 	constructor() {


### PR DESCRIPTION
``` js
.catch(res => {
  // 如果返回reject()，不让其进入this.$u.post().then().catch()后面的catct()
  // 因为很多人都会忘了写后面的catch()，导致报错捕获不到catch
  return new Promise(()=>{});
})
```
很多人? 请问您指哪些人？这个bug我找了一下午，到现在晚上了才发现最后还有这么个奇葩catch...
我真的很服气老哥，你这直接给忽略了，那我错误处理怎么走？有的页面调用后都会有一些后续的错误处理，你这倒好，直接从根源给我干死了？
你们不用不代表没有人用好吗？你让写这行注释的老哥怎么想？？
``` js
// 如果拦截器返回false，意味着拦截器定义者认为返回有问题，直接接入catch回调
```
😒😒😒😒😒