### PR TITLE
fix: card boxShadow prop type error

### DIFF
--- a/uview-ui/components/u-card/u-card.vue
+++ b/uview-ui/components/u-card/u-card.vue
@@ -224,7 +224,7 @@ export default {
 		},
 		// 卡片外围阴影，字符串形式
 		boxShadow: {
-			type: Boolean,
+			type: String,
 			default: 'none'
 		}
 	},


### PR DESCRIPTION
修复 Card 组件的 `boxShadow ` 属性类型错误的问题，该问题会导致以下 warn:

```
[Vue warn]: Invalid prop: type check failed for prop "boxShadow". Expected Boolean, got String with value "none".
```