### PR TITLE
Formatting ISO datetime

### DIFF
--- a/uview-ui/libs/function/timeFormat.js
+++ b/uview-ui/libs/function/timeFormat.js
@@ -24,9 +24,15 @@ if (!String.prototype.padStart) {
 function timeFormat(timestamp = null, fmt = 'yyyy-mm-dd') {
 	// 其他更多是格式化有如下:
 	// yyyy:mm:dd|yyyy:mm|yyyy年mm月dd日|yyyy年mm月dd日 hh时MM分等,可自定义组合
-	timestamp = parseInt(timestamp);
+	// 如果输入的是Number类型，直接转换成整数；如果是String类型，使用new Date转换Unix Timestamp或ISO类型成Timestamp。
+	timestamp =
+		typeof timestamp === "number"
+			? parseInt(timestamp)
+			: Number(new Date(timestamp));
 	// 如果为null,则格式化当前时间
-	if (!timestamp) timestamp = Number(new Date());
+	if (!timestamp || timestamp <= 0) {
+		timestamp = Number(new Date());
+	}
 	// 判断用户输入的时间戳是秒还是毫秒,一般前端js获取的时间戳是毫秒(13位),后端传过来的为秒(10位)
 	if (timestamp.toString().length == 10) timestamp *= 1000;
 	let date = new Date(timestamp);


### PR DESCRIPTION
The timeFormat module can only format Unix timestamp now. I add a feature to format ISO datetime, which is a common demand during developing.

I will write the related document after you testing and merging this PR.