### PR TITLE
上传图片完成后可能不触发 on-uploaded 事件问题；调整判断是否完全上传完成时机

### DIFF
--- a/uview-ui/components/u-upload/u-upload.vue
+++ b/uview-ui/components/u-upload/u-upload.vue
@@ -371,16 +371,20 @@ export default {
 		async uploadFile(index = 0) {
 			if (this.disabled) return;
 			if (this.uploading) return;
+
+			// 检查是否是已上传或者正在上传中
+			if (this.lists[index].progress == 100) {
+				// if (this.autoUpload == false) this.uploadFile(index + 1);
+				this.uploadFile(index + 1);
+				return;
+			}
+
 			// 全部上传完成
 			if (index >= this.lists.length) {
 				this.$emit('on-uploaded', this.lists, this.index);
 				return;
 			}
-			// 检查是否是已上传或者正在上传中
-			if (this.lists[index].progress == 100) {
-				if (this.autoUpload == false) this.uploadFile(index + 1);
-				return;
-			}
+			
 			// 执行before-upload钩子
 			if(this.beforeUpload && typeof(this.beforeUpload) === 'function') {
 				// 执行回调，同时传入索引和文件列表当作参数


### PR DESCRIPTION
```
// 检查是否是已上传或者正在上传中
if (this.lists[index].progress == 100) {
    if (this.autoUpload == false) this.uploadFile(index + 1);
    return;
}
```
这段代码会导致，如果配置为自动上传模式，在选择多张图片的时候，如果第一张图片失败，后面的图片上传成功，此时如果【点击重试】重新上传第一张图片，上传完后，不会触发 on-uploaded 事件，因为判断不到最后一张图片索引了 ，所以 里面 if 判断应该不需要会合理些

```
// 检查是否是已上传或者正在上传中
if (this.lists[index].progress == 100) {
    this.uploadFile(index + 1);
    return;
}
```

同时调整了判断是否完全上传完逻辑的时机，延后判断；先判断当前索引的图片是否已上传，然后判断当前索引是否为最后一张图片