### PR TITLE
修复#516 瀑布流组件重新赋值新list会有重复问题 #516

### DIFF
--- a/uview-ui/components/u-waterfall/u-waterfall.vue
+++ b/uview-ui/components/u-waterfall/u-waterfall.vue
@@ -101,6 +101,15 @@ export default {
 		cloneData(data) {
 			return JSON.parse(JSON.stringify(data));
 		},
+		
+		//重新渲染数据
+		reloadData(){
+			this.leftList = [];
+			this.rightList = [];
+			this.tempList = this.cloneData(this.copyFlowList);
+			this.splitData();
+		},
+		
 		// 清空数据列表
 		clear() {
 			this.leftList = [];


### PR DESCRIPTION
添加了一个重新渲染的方法，不然给瀑布流的flowList重新赋值 瀑布流组件会当成增加操作 ，比如在下拉刷新的场景flowlist可能在个数上只增加了一个 但是排序的方式变了,数据已经不一样了 也会被此监听当成新增 造成重复问题