### PR TITLE
【修复】u-swipe-action组件open和close事件触发逻辑

### DIFF
--- a/uview-ui/components/u-swipe-action/u-swipe-action.vue
+++ b/uview-ui/components/u-swipe-action/u-swipe-action.vue
@@ -183,8 +183,6 @@ export default {
 						this.emitCloseEvent();
 					} else {
 						this.moveX = -this.allBtnWidth;
-						this.status = true;
-						this.emitOpenEvent();
 					}
 				}
 			});
@@ -208,10 +206,11 @@ export default {
 		},
 		// 点击内容触发事件
 		contentClick() {
-			// 点击内容时，如果当前为打开状态，收起组件
+			// 点击内容时，如果当前为打开状态，收起组件，并触发close事件
 			if (this.status == true) {
-				this.status = 'close';
+				this.status = false;
 				this.moveX = 0;
+				this.emitCloseEvent();
 			}
 			this.$emit('content-click', this.index);
 		}


### PR DESCRIPTION
当使用左右滑去触发组件展开收缩时，能够正确触发open和close事件，当时当展开组件时，使用点击内容，虽然组件样式会收缩起来，但是触发的事件却是open，并且没有触发close事件

#### 触发close事件
看源码点击时的处理是
```
		// 点击内容触发事件
		contentClick() {
			// 点击内容时，如果当前为打开状态，收起组件
			if (this.status === true) {
			 	this.status = 'close';
			 	this.moveX = 0;
			}
			this.$emit('content-click', this.index);
		}
```
希望建议能改成，这样能够正确触发close事件了
```
		// 点击内容触发事件
		contentClick() {
			// 点击内容时，如果当前为打开状态，收起组件
			if (this.status === true) {
			 	//this.status = 'close';
			 	//this.moveX = 0;
				this.moveX = 0;
				this.status = false;
				this.emitCloseEvent();
			}
			this.$emit('content-click', this.index);
		}
```

#### 取消触发open事件
```
                // 用户手指离开movable-view元素，停止触摸
		touchend() {
                    ...
                        if (this.status == false) {
                            ...
                        }else{
				if (this.scrollX > (-this.allBtnWidth * 3) / 4) {
					this.moveX = 0;
					this.$nextTick(() => {
						this.moveX = 101;
					});
					this.status = false;
					this.emitCloseEvent();
				} else {
					this.moveX = -this.allBtnWidth;
                                        // 建议取消此处这两行代码，首先本是status=true才会进入此处所以再次赋值true没必要，其次进入此处是本已经展开状态的了，无需再次emit一次open请求，也能解决通过点击的方式收缩组件却触发了open事件
					// this.status = true;
					// this.emitOpenEvent();
				}
                        }
                    ...
                }
```