### PR TITLE
fix: 修复 Checkbox 和 Radio 组件由于 margin 样式导致 Label 一定概率捕获不到点击的 bug

### DIFF
--- a/uview-ui/components/u-checkbox/u-checkbox.vue
+++ b/uview-ui/components/u-checkbox/u-checkbox.vue
@@ -271,8 +271,9 @@
 	
 		&__label {
 			word-wrap: break-word;
-			margin-left: 10rpx;
-			margin-right: 24rpx;
+			padding-left: 10rpx;
+			padding-right: 10rpx;
+			margin-right: 14rpx;
 			color: $u-content-color;
 			font-size: 30rpx;
 			

--- a/uview-ui/components/u-radio/u-radio.vue
+++ b/uview-ui/components/u-radio/u-radio.vue
@@ -258,8 +258,9 @@
 		
 		&__label {
 			word-wrap: break-word;
-			margin-left: 10rpx;
-			margin-right: 24rpx;
+			padding-left: 10rpx;
+			padding-right: 10rpx;
+			margin-right: 14rpx;
 			color: $u-content-color;
 			font-size: 30rpx;
 			


### PR DESCRIPTION
由于 Label 文字部分使用了 margin 控制边距，导致 @tap 事件不能在整个 Label 区域生效，也就是说边距部分是点击无效的。因此，我将 margin 换成了 padding，同时保证升级之后外观没有任何变化，也没有带来新的问题。