### PR TITLE
修正手风琴折叠面板无法换行

### DIFF
--- a/uview-ui/components/u-collapse-item/u-collapse-item.vue
+++ b/uview-ui/components/u-collapse-item/u-collapse-item.vue
@@ -18,7 +18,7 @@
 				height: isShow ? height + 'px' : '0'
 			}]">
 			<view class="u-collapse-content" :id="elId" :style="[bodyStyle]">
-				<slot></slot>
+				<text><slot></slot><text>
 			</view>
 		</view>
 	</view>


### PR DESCRIPTION
用的子节点，默认是view，view不支持换行
更改前
![image](https://user-images.githubusercontent.com/34962267/97881659-a3129480-1d5d-11eb-8c71-c3a5954843ef.png)
更改后
![image](https://user-images.githubusercontent.com/34962267/97881636-9beb8680-1d5d-11eb-96ab-2afb660f133b.png)
