### PR TITLE
优化deepMerge，使其支持多参数

### DIFF
--- a/uview-ui/libs/function/deepMerge.js
+++ b/uview-ui/libs/function/deepMerge.js
@@ -1,7 +1,7 @@
 import deepClone from "./deepClone";
 
 // JS对象深度合并
-function deepMerge(target = {}, source = {}) {
+function _merge(target = {}, source = {}) {
 	target = deepClone(target);
 	if (typeof target !== 'object' || typeof source !== 'object') return false;
 	for (var prop in source) {
@@ -25,6 +25,12 @@ function deepMerge(target = {}, source = {}) {
 		}
 	}
 	return target;
+}
+
+function deepMerge() {
+  return [...arguments].reduce((target, current) => {
+    return _merge(target, current)
+  })
 }
 
 export default deepMerge;


### PR DESCRIPTION
原方法只支持传入source、target两个参数，与lodash、Object.assign等方法使用习惯不符，比较反直觉。
优化后可以支持多参数调用，如
```
const res = deepMerge({ a: 1 }, { b: 2}, { a: 3 }) // { a: 3, b: 2 }
```