### PR TITLE
修复SwipeAction组件初始化时宽度闪烁的问题

### DIFF
--- a/uview-ui/components/u-swipe-action/u-swipe-action.vue
+++ b/uview-ui/components/u-swipe-action/u-swipe-action.vue
@@ -10,7 +10,7 @@
 				:disabled="disabled"
 				:x="moveX"
 				:style="{
-					width: movableViewWidth ? movableViewWidth : '100%'
+					width: movableAreaWidth ? movableViewWidth : '100%'
 				}"
 			>
 				<view


### PR DESCRIPTION
movableViewWidth是计算属性，返回内容是'${n}px'。
永远不可能为false，所以不会执行到'100%'那里。
而movableAreaWidth初始值为0，导致movableViewWidth初始值为操作栏的宽度。所以组件初始化时，宽度会先是一个很小的数值，然后闪烁一下恢复正常。
将条件判断改为movableAreaWidth即可解决这个问题。