### PR TITLE
修复u-form无法全局隐藏表单成员下划线的问题

### DIFF
--- a/uview-ui/components/u-form-item/u-form-item.vue
+++ b/uview-ui/components/u-form-item/u-form-item.vue
@@ -212,8 +212,7 @@
 			// label的下划线
 			elBorderBottom() {
 				// 子组件的borderBottom默认为空字符串，如果不等于空字符串，意味着子组件设置了值，优先使用子组件的值
-				return this.borderBottom !== '' ? this.borderBottom : this.parentData.borderBottom ? this.parentData.borderBottom :
-					true;
+				return this.borderBottom !== '' ? this.borderBottom : this.parentData.borderBottom;
 			}
 		},
 		methods: {


### PR DESCRIPTION
文档中写了
> border-bottom是否显示表单域的下划线，如果给Input组件配置了边框，可以将此属性设置为false，从而隐藏默认的下划线。
实际使用发现设置为false并没有效果
因为
```
return this.borderBottom !== '' ? this.borderBottom : this.parentData.borderBottom ? this.parentData.borderBottom :
					true;
```
这句话在表单全局为false的时候仍然返回true