### PR TITLE
修复$u.route({type: 'back'})执行报错的问题

### DIFF
--- a/uview-ui/libs/function/route.js
+++ b/uview-ui/libs/function/route.js
@@ -53,9 +53,9 @@ class Router {
 			mergeConfig.url = this.mixinParam(options, params)
 			mergeConfig.type = 'navigateTo'
 		} else {
-			mergeConfig = uni.$u.deepClone(options, this.config)
+			mergeConfig = uni.$u.deepMerge(this.config, options)
 			// 否则正常使用mergeConfig中的url和params进行拼接
-			mergeConfig.url = this.mixinParam(options.url, options.params)
+			mergeConfig.url = this.mixinParam(mergeConfig.url, mergeConfig.params)
 		}
 		
 		if(params.intercept) {


### PR DESCRIPTION
11月10号提交的版本route.js存在显著bug，会导致执行`$u.route({type: 'back'})`时报错：

```
TypeError: Cannot read property '0' of undefined
    at Router.addRootPath (route.js:26)
    at Router.mixinParam (route.js:31)
```

原因是route.js第58行：
```
      mergeConfig = uni.$u.deepClone(options, this.config)
      // 否则正常使用mergeConfig中的url和params进行拼接
      mergeConfig.url = this.mixinParam(options.url, options.params)
```
deepMerge写成了deepClone，且合并的先后顺序也反了。
同时，mixinParam的对象也取错了，导致上一步的合并失去意义。
现改为：
```
			mergeConfig = uni.$u.deepMerge(this.config, options)
			// 否则正常使用mergeConfig中的url和params进行拼接
			mergeConfig.url = this.mixinParam(mergeConfig.url, mergeConfig.params)
```