### PR TITLE
使request拦截器支持Promise返回

### DIFF
--- a/uview-ui/libs/request/index.js
+++ b/uview-ui/libs/request/index.js
@@ -17,6 +17,10 @@ class Request {
 				// 返回一个处于pending状态中的Promise，来取消原promise，避免进入then()回调
 				return new Promise(()=>{});
 			}
+			// 支持Promise返回
+			if (interceptorRequest.then) {
+				return interceptorRequest;
+			}
 			this.options = interceptorRequest;
 		}
 		options.dataType = options.dataType || this.config.dataType;


### PR DESCRIPTION
相关问题 https://github.com/YanxinNet/uView/issues/121 https://github.com/YanxinNet/uView/issues/97

有时候我们希望在请求时拦截，做一些网络请求，来获取权限如token，但网络请求是异步的，所以我们需要request拦截器同样支持异步

*可能有比`interceptorRequest.then`更好的判断是否是Promise*