### PR TITLE
u-form-item 增加动态表单验证和对象数据的的验证

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.hbuilderx/*
 /unpackage/dist/*
 /node_modules/*
 /.idea/*

--- a/pages.json
+++ b/pages.json
@@ -53,10 +53,20 @@
 				}
 			}
 		}
-	],
+    ],
 	"subPackages": [{
 			"root": "pages/componentsC",
 			"pages": [
+				// 动态表单的测试
+				{
+				    "path" : "dynamicForm/dynamicForm",
+				    "style" :                                                                                    
+				    {
+				        "navigationBarTitleText": "动态表单的测试",
+				        "enablePullDownRefresh": false
+				    }
+				    
+				},
 				// test-测试
 				{
 					"path": "test/index",

--- a/pages/componentsC/dynamicForm/dynamicForm.vue
+++ b/pages/componentsC/dynamicForm/dynamicForm.vue
@@ -1,0 +1,50 @@
+<template>
+	<view>
+		<u-form :model="form" ref="uForm">
+			<u-divider>动态表单的验证</u-divider>
+			<u-form-item v-for="(item,index) in form.names" :prop="'names.'+index+'.name'" :rule="[{required: true,message: '请输入姓名',trigger: 'blur'}]">
+				<u-input v-model="item.name"></u-input>
+			</u-form-item>
+			<u-divider>对象的验证</u-divider>
+			<u-form-item  prop="person.name">
+				<u-input v-model="form.person.name"></u-input>
+			</u-form-item>
+		</u-form>
+	</view>
+</template>
+
+<script>
+	export default {
+		data() {
+			return {
+				form:{
+					name:"",
+					person:{
+						name:""
+					},
+					names:[{
+						name:""
+					}]
+				},
+				rules:{
+					'person.name':[{required: true,message: '请输入姓名',trigger: 'blur'}]
+				}
+			}
+		},
+		mounted() {
+			setTimeout(()=>{
+				this.form.names.push({name:""})
+			},5000)
+		},
+		methods: {
+			
+		},
+		onReady() {
+				this.$refs.uForm.setRules(this.rules);
+		}
+	}
+</script>
+
+<style>
+
+</style>

--- a/uview-ui/components/u-form-item/u-form-item.vue
+++ b/uview-ui/components/u-form-item/u-form-item.vue
@@ -285,7 +285,7 @@
 			validation(trigger, callback = () => {}) {
 				// 根据传入的prop的文字,切割出来后，递归获取数据
 				const propsFields = this.prop.split('.')
-				// 递归花去数据 替换之前的获取过去方式，因为有动态表单数据后，无法获取值
+				// 递归获取数据 替换之前的获取过去方式，因为有动态表单数据后，无法获取值
 				this.fieldValue = propsFields.reduce((current, item) => {
 					return current[item]
 				}, this.parent.model)

--- a/uview-ui/components/u-form-item/u-form-item.vue
+++ b/uview-ui/components/u-form-item/u-form-item.vue
@@ -266,7 +266,13 @@
 
 			// 过滤出符合要求的rule规则
 			getFilteredRule(triggerType = '',rules) {
-				rules = rules || this.getRules();
+				// 判断传入的规则，使用的是form传入的规则还是从当前组件传入的规则
+				if(rules.length){
+					rules = rules;
+				}else{
+					rules =  this.getRules();
+				}
+				
 				// 整体验证表单时，triggerType为空字符串，此时返回所有规则进行验证
 				if (!triggerType) return rules;
 				// 历遍判断规则是否有对应的事件，比如blur，change触发等的事件

--- a/uview-ui/components/u-form-item/u-form-item.vue
+++ b/uview-ui/components/u-form-item/u-form-item.vue
@@ -142,6 +142,11 @@
 			required: {
 				type: Boolean,
 				default: false
+			},
+			// 当前组件的验证器，主要用户动态表单验证使用
+			rule: {
+				type: Array,
+				default: ()=>[]
 			}
 		},
 		data() {
@@ -260,8 +265,8 @@
 			},
 
 			// 过滤出符合要求的rule规则
-			getFilteredRule(triggerType = '') {
-				let rules = this.getRules();
+			getFilteredRule(triggerType = '',rules) {
+				rules = rules || this.getRules();
 				// 整体验证表单时，triggerType为空字符串，此时返回所有规则进行验证
 				if (!triggerType) return rules;
 				// 历遍判断规则是否有对应的事件，比如blur，change触发等的事件
@@ -272,10 +277,16 @@
 
 			// 校验数据
 			validation(trigger, callback = () => {}) {
-				// 检验之间，先获取需要校验的值
-				this.fieldValue = this.parent.model[this.prop];
-				// blur和change是否有当前方式的校验规则
-				let rules = this.getFilteredRule(trigger);
+				// 根据传入的prop的文字,切割出来后，递归获取数据
+				const propsFields = this.prop.split('.')
+				// 递归花去数据 替换之前的获取过去方式，因为有动态表单数据后，无法获取值
+				this.fieldValue = propsFields.reduce((current, item) => {
+					return current[item]
+				}, this.parent.model)
+				
+				// let rules = this.getFilteredRule(trigger);
+				//  blur和change是否有当前方式的校验规则,如果this.rule 存在则过滤this.rule 否则过滤全局
+				let rules = this.getFilteredRule(trigger,this.rule);
 				// 判断是否有验证规则，如果没有规则，也调用回调方法，否则父组件u-form会因为
 				// 对count变量的统计错误而无法进入上一层的回调
 				if (!rules || rules.length === 0) {


### PR DESCRIPTION
主要修改u-form-item的 validation 和getFilteredRule 函数，主要从两个方面修改
1、修改函数获取表单的数据，从直接通过key获取，变成递归获取，将传入的prop 使用点分割后，变成数据，然后递归获取
2、修改 getFilteredRule 函数增加 rule 参数，优先从rule参数获取

注：动态表单只能通过u-form-item 的rule传入， 动态表单验证和深度对象的数据验证测试文件在  pages/componentsC/dynamicForm/dynamicForm 下