### PR TITLE
fix: deepMerge error

### DIFF
--- a/uview-ui/libs/function/deepMerge.js
+++ b/uview-ui/libs/function/deepMerge.js
@@ -10,10 +10,10 @@ function deepMerge(target = {}, source = {}) {
 			if (typeof target[prop] !== 'object') {
 				target[prop] = source[prop];
 			} else {
-				if (typeof source[prop] !== 'object') {
+				if (typeof source[prop] !== 'object' || target[prop] === null) {
 					target[prop] = source[prop];
 				} else {
-					if (target[prop] && target[prop].concat && source[prop].concat) {
+					if (target[prop].concat && source[prop].concat) {
 						target[prop] = target[prop].concat(source[prop]);
 					} else {
 						target[prop] = deepMerge(target[prop], source[prop]);


### PR DESCRIPTION
```js
const target = { value: null }
console.log(deepMerge(target, target)); // Error 
```