### PR TITLE
fix(u-message-input): 修复设置 maxlength 属性值为 String 类型时无效的问题

### DIFF
--- a/uview-ui/components/u-message-input/u-message-input.vue
+++ b/uview-ui/components/u-message-input/u-message-input.vue
@@ -158,7 +158,7 @@
 			},
 			// 根据长度，循环输入框的个数，因为头条小程序数值不能用于v-for
 			loopCharArr() {
-				return new Array(this.maxlength);
+				return new Array(Number(this.maxlength));
 			}
 		},
 		methods: {


### PR DESCRIPTION
问题如下：

```html
<u-message-input
  maxlength="5" // 无效，反而只显示一个输入格
  value="46821"
></u-message-input>
```

```html
<u-message-input
  :maxlength="5" // 有效
  value="46821"
></u-message-input>
```