### PR TITLE
fix: radio的name为数字0使会出现同时具有多个选中项的问题。

### DIFF
--- a/uview-ui/components/u-radio/u-radio.vue
+++ b/uview-ui/components/u-radio/u-radio.vue
@@ -121,7 +121,7 @@
 			// 设置radio的状态，要求radio的name等于parent的value时才为选中状态
 			iconStyle() {
 				let style = {};
-				if (this.elActiveColor && this.parentData.value == this.name && !this.elDisabled) {
+				if (this.elActiveColor && this.parentData.value === this.name && !this.elDisabled) {
 					style.borderColor = this.elActiveColor;
 					style.backgroundColor = this.elActiveColor;
 				}
@@ -181,7 +181,7 @@
 			},
 			emitEvent() {
 				// u-radio的name不等于父组件的v-model的值时(意味着未选中)，才发出事件，避免多次点击触发事件
-				if(this.parentData.value != this.name) this.$emit('change', this.name);
+				if(this.parentData.value !== this.name) this.$emit('change', this.name);
 			},
 			// 改变组件选中状态
 			// 这里的改变的依据是，更改本组件的parentData.value值为本组件的name值，同时通过父组件遍历所有u-radio实例


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37258929/116640176-db0d3400-a99c-11eb-9bd9-27d7ca44afae.png)
问题如上。由于都不选的默认值''在==下的判定与0相等。