### PR TITLE
dropItem销毁前从父组件中删除

### DIFF
--- a/uview-ui/components/u-dropdown-item/u-dropdown-item.vue
+++ b/uview-ui/components/u-dropdown-item/u-dropdown-item.vue
@@ -123,7 +123,13 @@
 		},
 		mounted() {
 			this.init();
-		}
+		},
+		beforeDestroy(){
+			let  index =  this.parent.menuList.findIndex(item=>item.title==this.title)
+			if(index!==-1){
+				this.parent.menuList.splice(index)
+			}
+		},	
 	}
 </script>
 


### PR DESCRIPTION
u-dropdown销毁前从父组件u-dropdown中删除自己
```vue
  <u-dropdown style="background-color: #fff">
      <u-dropdown-item
        v-model="value1"
        title="Item1"
        :options="options2"
      />
      <u-dropdown-item
        v-model="value2"
        title="item2"
        :options="options2"
        v-if="showOption2"
       />
   </u-dropdown>
```
解决了之前因为showOption2变化，多出无效的dropItem组件的问题